### PR TITLE
Update for Cabal 2.x

### DIFF
--- a/cabal-dependency-licenses.cabal
+++ b/cabal-dependency-licenses.cabal
@@ -1,5 +1,5 @@
 Name:     cabal-dependency-licenses
-Version:  0.2.0.0
+Version:  0.2.0.1
 Synopsis: Compose a list of a project's transitive dependencies with their licenses
 
 Description:
@@ -24,7 +24,7 @@ Executable cabal-dependency-licenses
   Ghc-options:         -Wall
 
   Build-depends:
-    Cabal      >= 1.24 && < 1.25,
+    Cabal      >= 2,
     containers >= 0.5  && < 0.6,
     base       >= 4    && < 5,
     directory  >= 1.2  && < 1.4,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,6 +12,7 @@ import           Data.Maybe                         (catMaybes)
 import           Data.Ord                           (comparing)
 import           Data.Set                           (Set)
 import qualified Data.Set                           as Set
+import qualified Data.Map                           as Map
 import           Distribution.InstalledPackageInfo  (InstalledPackageInfo)
 import qualified Distribution.InstalledPackageInfo  as InstalledPackageInfo
 import qualified Distribution.License               as Cabal
@@ -73,7 +74,7 @@ getDependencyInstalledPackageIds lbi =
     findTransitiveDependencies (Cabal.installedPkgs lbi) $
         Set.fromList
             [ installedPackageId
-            | (_, componentLbi, _)    <- Cabal.componentsConfigs lbi
+            | componentLbi    <- concat (Map.elems (Cabal.componentNameMap lbi))
             , (installedPackageId, _) <- Cabal.componentPackageDeps componentLbi
             ]
 


### PR DESCRIPTION
This is NOT backwards compatible - consider the obvious CPP if such compatibility is desired.